### PR TITLE
feat: add optional keys to object schema

### DIFF
--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -27,6 +27,7 @@ test('Can generate a valid json schema', () => {
             thing4: { type: 'string' as 'string' },
         },
         additionalProperties: false,
+        required: ['thing', 'thing2', 'thing3', 'thing4'],
     };
 
     expect(schema).toEqual(expected);

--- a/tests/unit/object.test.ts
+++ b/tests/unit/object.test.ts
@@ -44,3 +44,48 @@ test('Can validate a deep object', () => {
         fail();
     }
 });
+
+test('Can validate an object cannot be missing a property', () => {
+    const x: any = {
+        a: 'hi',
+        b: 22,
+    };
+
+    const validator = v.object({
+        a: v.string(),
+        b: v.number(),
+        c: v.boolean(),
+    });
+
+    if (validator.isValid(x)) fail();
+    else pass();
+});
+
+test('Can make certain object properties optional', () => {
+    const x: any = {
+        a: 'yellow',
+        b: 22,
+    };
+
+    const validator = v.object({
+        a: v.string(),
+        b: v.number(),
+        c: v.boolean(),
+    }, {
+        optional: ['c'],
+    });
+
+    if (validator.isValid(x)) {
+        pass();
+
+        interface Type {
+            a: string;
+            b: number;
+            c?: boolean;
+        }
+
+        assertTypesEqual<typeof x, Type>();
+    } else {
+        fail();
+    }
+});


### PR DESCRIPTION
JSON schema allows you to specify the required keys for an object
schema. Typescript allows you to specify which keys are optional. I
think that TS made the better decision, as more often than not I want my
objects to require most keys and have only a few optional.

Perhaps future work could allow consumers to specify either optional
keys or required keys.