### PR TITLE
fix: ensure type params have unique names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { objectKeys, Nominal, AnyFunc, AllRequired, Optional } from 'simplytyped
 import * as Ajv from 'ajv';
 
 type ObjectValidator<O extends Record<string, Validator<any>>, OptionalKeys extends keyof O> = Optional<{
-    [S in keyof O]: O[S] extends Validator<infer T> ? T : any;
+    [S in keyof O]: O[S] extends Validator<infer X> ? X : any;
 }, OptionalKeys>;
 
 type UnionValidator<V extends Validator<any>> = V extends Validator<infer T> ? T : any;


### PR DESCRIPTION
It appears that TS has a bug in its static analysis of static class
members. If an infered type param in a static class member has the same
name as a type param for the class, TS 2.9 will report an erroroneous
use of class type params in a static method.

I'm going to try to get a smaller reproduction, then will open a TS
issue.