### PR TITLE
feat: add Record type validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,10 +66,18 @@ export default class Validator<T> {
         });
     }
 
+    static record<T>(types: Validator<T>) {
+        return new Validator<Record<string, T>>({
+            type: 'object',
+            additionalProperties: types.getSchema(),
+        });
+    }
+
     static array<V extends Validator<any>>(v: V[]) {
         return new Validator<Array<UnionValidator<V>>>({
             type: 'array',
             items: v.map(x => x.getSchema()),
+            additionalItems: true,
         });
     }
 

--- a/tests/unit/record.test.ts
+++ b/tests/unit/record.test.ts
@@ -1,0 +1,34 @@
+import v from 'index';
+import { fail, pass, assertTypesEqual } from '../helpers/assert';
+
+test('Can validate a record', () => {
+    const x: any = {
+        a: 22,
+        b: 'merp',
+    };
+
+    const validator = v.record(v.union([ v.string(), v.number() ]));
+
+    if (validator.isValid(x)) {
+        type got = typeof x;
+        type expected = Record<string, string | number>;
+        assertTypesEqual<got, expected>();
+        assertTypesEqual<expected, got>();
+        pass();
+    } else {
+        fail();
+    }
+});
+
+test('Can validate not a correct record', () => {
+    const x: any = {
+        a: 22,
+        b: 'merp',
+        c: false,
+    };
+
+    const validator = v.record(v.union([ v.string(), v.number() ]));
+
+    if (validator.isValid(x)) fail();
+    else pass();
+});


### PR DESCRIPTION
There are many times when we use a javascript object to contain a record
of unknown keys (also called a dictionary or map). We can specify this
type with JSON schema using the `additionalProperties` field of the
object schema type.

For instance:
```JSON
{
    "type": "object",
    "additionalProperties": { "type": "string" }
}
```
would match:
```JSON
{
    "hi": "there",
    "my": "friend",
}
```
but not:
```JSON
{
    "x": 22,
    "y": 2,
}
```