### PR TITLE
Other validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,22 @@ if (result.valid) doThing(result.data);
 else logger.error(...result.errors);
 ```
 
+### Validator.withOptions
+Add additional validations to the generated schema.
+While most of these validations are not representable at compile time
+with typescript (`minLength` of a `string` for instance), it can be helpful
+to have the additional validations when validating runtime types.
+
+| Param | Description |
+| --- | --- |
+| opts | JSON schema specific options (for instance: `{ maxLength: 2, minLength: 0 }`) |
+###### Example:
+ ```typescript
+const validator = v.string().withOptions({ minLength: 1 });
+validator.isValid(''); // false
+validator.isValid('hi'); // true
+```
+
 ### ValidType
 Returns the encapsulated type of a `Validator` type.
 ###### Example:

--- a/tests/unit/array.test.ts
+++ b/tests/unit/array.test.ts
@@ -30,3 +30,14 @@ test('Can validate a deep array', () => {
         fail();
     }
 });
+
+test('Can add JSON Schema options', () => {
+    const x: any = [ 'yellow!' ];
+
+    const validator = v.array(v.any())
+        .withOptions({ minItems: 2 });
+
+    // expect to fail because we have fewer than 2 items
+    if (validator.isValid(x)) fail();
+    else pass();
+});

--- a/tests/unit/string.test.ts
+++ b/tests/unit/string.test.ts
@@ -35,3 +35,13 @@ test('String is not in enum', () => {
     if (validator.isValid(x)) fail();
     else pass();
 });
+
+test('Can add JSON Schema options', () => {
+    const x: any = '';
+
+    const validator = v.string()
+        .withOptions({ minLength: 1 });
+
+    if (validator.isValid(x)) fail();
+    else pass();
+});


### PR DESCRIPTION
It'll be convenient to be able to specify other validations to the schema validator. While I'm not sure that I strictly believe in these additional validations, it'll make migrating from a JSON schema project to a `validtyped` project easier if we support them.