### PR TITLE
test: check that empty arrays pass

### DIFF
--- a/tests/unit/array.test.ts
+++ b/tests/unit/array.test.ts
@@ -41,3 +41,15 @@ test('Can add JSON Schema options', () => {
     if (validator.isValid(x)) fail();
     else pass();
 });
+
+test('Can validate empty array', () => {
+    const x: any = [];
+
+    const validator = v.array(v.number());
+    if (validator.isValid(x)) {
+        assertTypesEqual<typeof x, number[]>();
+        pass();
+    } else {
+        fail();
+    }
+});


### PR DESCRIPTION
While debugging an unrelated issue, I thought there may be a bug
with empty arrays being rejected as valid input. Since there was no
unit test covering this case, I was unable to rule this out. This
wasted some debugging time following a red herring. So here is a unit
test to cover this case so that in the future I only need to check the
unit tests to this out as a potential source of bug.